### PR TITLE
Trimming string from the feature file descriptions. Fixing issue #3

### DIFF
--- a/src/Context/ContentModelContext.php
+++ b/src/Context/ContentModelContext.php
@@ -147,7 +147,7 @@ class ContentModelContext extends BaseContext {
             $field_storage->getCardinality() === -1 ? 'Unlimited' : $field_storage->getCardinality(),
             isset($form_components[$machine_name]['type']) ? (string) $this->fieldWidgetPluginManager->getDefinition($form_components[$machine_name]['type'])['label'] : '-- Disabled --',
             $field_config->isTranslatable() ? 'Translatable' : '',
-            $field_config->getDescription(),
+            trim($field_config->getDescription()),
           ];
         }
       }


### PR DESCRIPTION
# Changes
Added a trim to the call to $field_config->getDescription() in order to allow for the actual and expected values to match.