### PR TITLE
Update README install note for BLT

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ Assuming you already have [Behat installed](http://behat.org/en/latest/quick_sta
 
 1. Install the Behat contexts:
 
-    _Note: If you're using [BLT](https://github.com/acquia/blt) the Drupal Spec Tool is already included as part of `blt/composer.suggested.json`._
+    _Note: If you're using [BLT](https://github.com/acquia/blt) the Drupal Spec Tool is already included._
 
     ```bash
     composer require --dev acquia/drupal-spec-tool


### PR DESCRIPTION
The BLT package no longer uses the Composer merge plugin. 
Removing reference to `composer.suggested.json`.