### PR TITLE
Enable Drupal 10 ORCA (test) jobs

### DIFF
--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -55,13 +55,18 @@ jobs:
           # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           # - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_BETA_OR_LATER # Isolated upgrade test to next major beta-or-later Drupal core version.
           # - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV # Isolated upgrade test to next major dev Drupal core version.
+          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
         php-version: [ "7.4" ]
         include:
           # Acquia CMS/Spreadsheet/Behat integration test.
           - orca-job: "INTEGRATED_TEST_ON_CURRENT"
             php-version: "7.4"
             behat: "TRUE"
-
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.1"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.1"
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/orca.yml
+++ b/.github/workflows/orca.yml
@@ -55,8 +55,6 @@ jobs:
           # - INTEGRATED_UPGRADE_TEST_TO_NEXT_MINOR_DEV
           # - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_BETA_OR_LATER # Isolated upgrade test to next major beta-or-later Drupal core version.
           # - ISOLATED_UPGRADE_TEST_TO_NEXT_MAJOR_DEV # Isolated upgrade test to next major dev Drupal core version.
-          - ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
-          - INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
         php-version: [ "7.4" ]
         include:
           # Acquia CMS/Spreadsheet/Behat integration test.
@@ -66,6 +64,10 @@ jobs:
           - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
             php-version: "8.1"
           - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
+            php-version: "8.1"
+          - orca-job: ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
+            php-version: "8.1"
+          - orca-job: INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
             php-version: "8.1"
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**Motivation**
Enables jobs to test D10 readiness . [ORCA-411](https://backlog.acquia.com/browse/ORCA-411)

**Proposed changes**
Enabled the following jobs
1. ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
2. INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_DEV
3. ISOLATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER
4. INTEGRATED_TEST_ON_NEXT_MAJOR_LATEST_MINOR_BETA_OR_LATER