### PR TITLE
Add support for PHP 8.3 and Drupal 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "source": "https://github.com/acquia/drupal-spec-tool"
     },
     "require": {
-        "php": "^8.1|^8.2",
-        "drupal/core": "^10.0.0-alpha1",
+        "php": ">=8.1",
+        "drupal/core": ">=10.0.0-alpha1",
         "drupal/drupal-extension": "dev-main",
         "traviscarden/behat-table-comparison": "^0.3"
     },


### PR DESCRIPTION
This makes it possible to (Composer) install with PHP 8.3 and Drupal 11.